### PR TITLE
Explain how to achieve toggling without shift-key

### DIFF
--- a/src/selection.ts
+++ b/src/selection.ts
@@ -110,6 +110,9 @@ export interface MultiSelectionConfig extends BaseSelectionConfig {
    * __Default value:__ `true`, which corresponds to `event.shiftKey` (i.e.,
    * data values are toggled when a user interacts with the shift-key pressed).
    *
+   * Setting the value to the Vega expression `"true"` will toggle data values
+   * without the user pressing the shift-key.
+   *
    * __See also:__ [`toggle`](https://vega.github.io/vega-lite/docs/toggle.html) documentation.
    */
   toggle?: string | boolean;


### PR DESCRIPTION
This is an attempt to explain how to make it possible to toggle values without users pressing the shift-key.

See the discussion in https://github.com/altair-viz/altair/issues/2151. I read and re-read this part of the documentation but couldn’t for the life of me figure out how to enable toggling without using a modifier.